### PR TITLE
small corrections

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForChunkedUpload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForChunkedUpload.java
@@ -21,6 +21,7 @@ import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.hash.HashCode;
 import com.google.common.io.ByteProcessor;
 import com.google.common.net.HttpHeaders;
 import com.google.inject.Inject;
@@ -42,9 +43,7 @@ import java.util.Date;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.io.ByteStreams.readBytes;
-import static com.google.common.net.HttpHeaders.AUTHORIZATION;
-import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
-import static com.google.common.net.HttpHeaders.DATE;
+import static com.google.common.net.HttpHeaders.*;
 import static org.jclouds.aws.reference.AWSConstants.PROPERTY_HEADER_TAG;
 import static org.jclouds.s3.filters.AwsSignatureV4Constants.AMZ_ALGORITHM_HMAC_SHA256;
 import static org.jclouds.s3.filters.AwsSignatureV4Constants.AMZ_CONTENT_SHA256_HEADER;
@@ -195,7 +194,10 @@ public class Aws4SignerForChunkedUpload extends Aws4SignerBase {
         ChunkedUploadPayload chunkedPayload = new ChunkedUploadPayload(payload, userDataBlockSize, timestamp,
                 credentialScope, hmacSHA256, signature);
 
-        return request.toBuilder()
+        // remove the user specified content md5 - it is replaced by chunked signatures
+        chunkedPayload.getContentMetadata().setContentMD5((byte[]) null);
+
+        return requestBuilder
                 .replaceHeader(HttpHeaders.AUTHORIZATION, authorization.toString())
                 .payload(chunkedPayload)
                 .build();

--- a/apis/s3/src/main/java/org/jclouds/s3/filters/RequestAuthorizeSignatureV4.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/filters/RequestAuthorizeSignatureV4.java
@@ -47,7 +47,7 @@ public class RequestAuthorizeSignatureV4 implements RequestAuthorizeSignature {
         String method = request.getMethod();
         // only HTTP PUT method, payload not null and cannot repeatable
         if ("PUT".equals(method)
-                && payload != null && !payload.isRepeatable()) {
+                && payload != null && payload.getContentMetadata().getContentLength() > 0 && !payload.isRepeatable()) {
             return signForChunkedUpload(request);
         }
         return signForAuthorizationHeader(request);

--- a/core/src/main/java/org/jclouds/io/ContentMetadataBuilder.java
+++ b/core/src/main/java/org/jclouds/io/ContentMetadataBuilder.java
@@ -50,9 +50,7 @@ public class ContentMetadataBuilder {
    }
 
    public ContentMetadataBuilder contentMD5(@Nullable HashCode contentMD5) {
-      if (contentMD5 != null) {
-         this.contentMD5 = contentMD5;
-      }
+      this.contentMD5 = contentMD5;
       return this;
    }
 


### PR DESCRIPTION
Hi.

We've used your PR for v4 signatures, thanks! It works almost perfectly. After applying the fixes below, all our integration tests against Frankfurt (v4) worked! Maybe you find time to look through the changes and apply them to the original PR.

Needed changes due to:
- S3 rejected the requests, when an MD5 hash was provided by the client. Now, it is removed when sending the request
- Payloads with 0 byte streams failed. Which worked with the old v2 style
- Setting the Md5 to null on the ContentMetadataBuilder wasn't possible. So the hash couldn't be removed. If you look for references in the code, you'll find plenty of calls which try to set it to null. Obviously this hadn't any affect at all. So either the callers are wrong or ContentMetadataBuilder is :).
